### PR TITLE
fix: use the proper way to compare strings

### DIFF
--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -319,7 +319,7 @@ final class VideoPlayer {
   void selectTrack(String track) {
     int groupId = -1;
     for (int i = 0; i < exoPlayer.getCurrentTracks().getGroups().size(); i++) {
-      if (exoPlayer.getCurrentTracks().getGroups().get(i).getTrackFormat(0).label == track) {
+      if (track.equals(exoPlayer.getCurrentTracks().getGroups().get(i).getTrackFormat(0).label)) {
         groupId = i;
       }
    }


### PR DESCRIPTION
fix: use the proper way to compare strings