### PR TITLE
bug(android): update buffering metadata when any event emitted

### DIFF
--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -207,6 +207,12 @@ final class VideoPlayer {
           }
 
           @Override
+          public void onEvents(Player player, Player.Events events) {
+            sendBufferingUpdate();
+            Listener.super.onEvents(player, events);
+          }
+
+          @Override
           public void onPlaybackStateChanged(final int playbackState) {
             if (playbackState == Player.STATE_BUFFERING) {
               setBuffering(true);
@@ -302,7 +308,7 @@ final class VideoPlayer {
     for (int i = 0; i < exoPlayer.getCurrentTracks().getGroups().size(); i++) {
       if (exoPlayer.getCurrentTracks().getGroups().get(i).getTrackFormat(0).label != null) {
         tracks.add(exoPlayer.getCurrentTracks().getGroups().get(i).getTrackFormat(0).label);
-        
+
         if (exoPlayer.getCurrentTracks().getGroups().get(i).isSelected()) {
           selected = exoPlayer.getCurrentTracks().getGroups().get(i).getTrackFormat(0).label;
         }
@@ -323,7 +329,7 @@ final class VideoPlayer {
         groupId = i;
       }
    }
-    
+
     if (groupId  != -1) {
       exoPlayer.setTrackSelectionParameters(
           exoPlayer.getTrackSelectionParameters()


### PR DESCRIPTION
When the video is paused, 'onPlaybackStateChanged' callback is never called more than once, this happens because the state is not different from the previous. The problem occours because the current implementation just send bufferingUpdates when the state change from BUFFERING to READY for example, but based on the settings of the LoadControl that is responsible for downloading the video frames, it downloads until 50seconds of video, and the state could be ready but the segments under the hood is being cached in memory.

Based on the screenshot below, you could see that the state could be ready because is necessary at least 2.5 seconds to play a video, and this is enough to the state be ready to play and not buffering.

What I did is on any event emitted, We will update the metadata of buffering stored in the Dart layer that is the responsible for the bug mentioned in the card.

![Screenshot 2024-05-28 at 09 46 02](https://github.com/indaband/packages/assets/13079483/ceeed3e1-dc78-4a84-8042-59b8c02c38fe)

The OnEvents was suggested by the docs of Android https://developer.android.com/media/media3/exoplayer/listening-to-player-events#individual-callbacks

Solves the problem in the card: https://www.notion.so/indaband/Track-is-never-selected-when-there-are-some-tracks-selected-previously-352a9b946ef845989aab0c08be448291?pvs=4