### PR TITLE
feat(video_player): allow to start a video player in a given position

### DIFF
--- a/packages/video_player/video_player/example/android/app/build.gradle
+++ b/packages/video_player/video_player/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,22 +22,19 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
     namespace 'io.flutter.plugins.videoplayerexample'
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     defaultConfig {
         applicationId "io.flutter.plugins.videoplayerexample"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/video_player/video_player/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/video_player/video_player/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/video_player/video_player/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/video_player/video_player/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/video_player/video_player/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/video_player/video_player/example/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <activity
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection"
       android:hardwareAccelerated="true"
+      android:exported="true"
       android:name="io.flutter.embedding.android.FlutterActivity"
       android:theme="@style/LaunchTheme"
       android:windowSoftInputMode="adjustResize">

--- a/packages/video_player/video_player/example/android/build.gradle
+++ b/packages/video_player/video_player/example/android/build.gradle
@@ -11,6 +11,12 @@ buildscript {
 
 allprojects {
     repositories {
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
+        def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
+        if (System.getenv().containsKey(artifactRepoKey)) {
+            println "Using artifact hub"
+            maven { url System.getenv(artifactRepoKey) }
+        }
         google()
         mavenCentral()
     }

--- a/packages/video_player/video_player/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/video_player/video_player/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/packages/video_player/video_player/example/android/settings.gradle
+++ b/packages/video_player/video_player/example/android/settings.gradle
@@ -1,15 +1,27 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.5.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
 }
+
+include ":app"

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -228,7 +228,9 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
       setState(() {});
     });
     _controller.setLooping(true);
-    _controller.initialize();
+    _controller.initialize(
+      initialPosition: const Duration(seconds: 10),
+    );
   }
 
   @override

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -440,6 +440,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           initialPosition: initialPosition,
         )) ??
         kUninitializedTextureId;
+
+    if (initialPosition != null) {
+      _updatePosition(initialPosition);
+    }
+
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -389,7 +389,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   int get textureId => _textureId;
 
   /// Attempts to open the given [dataSource] and load metadata about the video.
-  Future<void> initialize() async {
+  Future<void> initialize({Duration? initialPosition}) async {
     final bool allowBackgroundPlayback =
         videoPlayerOptions?.allowBackgroundPlayback ?? false;
     if (!allowBackgroundPlayback) {
@@ -435,7 +435,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
     }
 
-    _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??
+    _textureId = (await _videoPlayerPlatform.create(
+          dataSourceDescription,
+          initialPosition: initialPosition,
+        )) ??
         kUninitializedTextureId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -456,6 +456,16 @@ public class Messages {
       this.httpHeaders = setterArg;
     }
 
+    private @Nullable Long initialPosition;
+
+    public @Nullable Long getInitialPosition() {
+      return initialPosition;
+    }
+
+    public void setInitialPosition(@Nullable Long setterArg) {
+      this.initialPosition = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     CreateMessage() {}
 
@@ -496,6 +506,13 @@ public class Messages {
         return this;
       }
 
+      private @Nullable Long initialPosition;
+
+      public @NonNull Builder setInitialPosition(@Nullable Long setterArg) {
+        this.initialPosition = setterArg;
+        return this;
+      }
+
       public @NonNull CreateMessage build() {
         CreateMessage pigeonReturn = new CreateMessage();
         pigeonReturn.setAsset(asset);
@@ -503,18 +520,20 @@ public class Messages {
         pigeonReturn.setPackageName(packageName);
         pigeonReturn.setFormatHint(formatHint);
         pigeonReturn.setHttpHeaders(httpHeaders);
+        pigeonReturn.setInitialPosition(initialPosition);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(5);
+      ArrayList<Object> toListResult = new ArrayList<Object>(6);
       toListResult.add(asset);
       toListResult.add(uri);
       toListResult.add(packageName);
       toListResult.add(formatHint);
       toListResult.add(httpHeaders);
+      toListResult.add(initialPosition);
       return toListResult;
     }
 
@@ -530,6 +549,8 @@ public class Messages {
       pigeonResult.setFormatHint((String) formatHint);
       Object httpHeaders = list.get(4);
       pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
+      Object initialPosition = list.get(5);
+      pigeonResult.setInitialPosition((initialPosition == null) ? null : ((initialPosition instanceof Integer) ? (Integer) initialPosition : (Long) initialPosition));
       return pigeonResult;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -158,6 +158,9 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
               httpHeaders,
               options);
     }
+    if (arg.getInitialPosition() != null) {
+      player.seekTo(arg.getInitialPosition().intValue());
+    }
     videoPlayers.put(handle.id(), player);
 
     return new TextureMessage.Builder().setTextureId(handle.id()).build();

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -31,7 +31,10 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<int?> create(DataSource dataSource) async {
+  Future<int?> create(
+    DataSource dataSource, {
+    Duration? initialPosition,
+  }) async {
     String? asset;
     String? packageName;
     String? uri;
@@ -61,6 +64,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       uri: uri,
       httpHeaders: httpHeaders,
       formatHint: formatHint,
+      initialPosition: initialPosition?.inMilliseconds,
     );
 
     final TextureMessage response = await _api.create(message);

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -143,6 +143,7 @@ class CreateMessage {
     this.packageName,
     this.formatHint,
     required this.httpHeaders,
+    this.initialPosition,
   });
 
   String? asset;
@@ -155,6 +156,8 @@ class CreateMessage {
 
   Map<String?, String?> httpHeaders;
 
+  int? initialPosition;
+
   Object encode() {
     return <Object?>[
       asset,
@@ -162,6 +165,7 @@ class CreateMessage {
       packageName,
       formatHint,
       httpHeaders,
+      initialPosition,
     ];
   }
 
@@ -172,7 +176,9 @@ class CreateMessage {
       uri: result[1] as String?,
       packageName: result[2] as String?,
       formatHint: result[3] as String?,
-      httpHeaders: (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      httpHeaders:
+          (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      initialPosition: result[5] as int?,
     );
   }
 }

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -49,6 +49,7 @@ class CreateMessage {
   String? packageName;
   String? formatHint;
   Map<String?, String?> httpHeaders;
+  int? initialPosition;
 }
 
 class MixWithOthersMessage {

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
@@ -126,7 +126,8 @@
                 uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
         packageName:nil
          formatHint:nil
-        httpHeaders:@{}];
+        httpHeaders:@{}
+    initialPosition:nil];
   FLTTextureMessage *textureMessage = [videoPlayerPlugin create:create error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(textureMessage);
@@ -157,7 +158,8 @@
                 uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
         packageName:nil
          formatHint:nil
-        httpHeaders:@{}];
+        httpHeaders:@{}
+    initialPosition:nil];
   FLTTextureMessage *textureMessage = [videoPlayerPlugin create:create error:&error];
   NSNumber *textureId = textureMessage.textureId;
 
@@ -191,7 +193,8 @@
                 uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
         packageName:nil
          formatHint:nil
-        httpHeaders:@{}];
+        httpHeaders:@{}
+    initialPosition:nil];
   FLTTextureMessage *textureMessage = [videoPlayerPlugin create:create error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(textureMessage);
@@ -287,7 +290,8 @@
                 uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
         packageName:nil
          formatHint:nil
-        httpHeaders:@{}];
+        httpHeaders:@{}
+    initialPosition:nil];
   FLTTextureMessage *textureMessage = [pluginWithMockAVPlayer create:create error:&error];
   NSNumber *textureId = textureMessage.textureId;
 
@@ -325,7 +329,8 @@
                 uri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
         packageName:nil
          formatHint:nil
-        httpHeaders:@{}];
+        httpHeaders:@{}
+    initialPosition:nil];
   FLTTextureMessage *textureMessage = [pluginWithMockAVPlayer create:create error:&error];
   NSNumber *textureId = textureMessage.textureId;
 
@@ -352,7 +357,8 @@
                                                          uri:uri
                                                  packageName:nil
                                                   formatHint:nil
-                                                 httpHeaders:@{}];
+                                                 httpHeaders:@{}
+                                             initialPosition:nil];
   FLTTextureMessage *textureMessage = [videoPlayerPlugin create:create error:&error];
 
   NSNumber *textureId = textureMessage.textureId;

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -274,17 +274,17 @@ NS_INLINE UIViewController *rootViewController(void) {
   _player = [playerFactory playerWithPlayerItem:item];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
 
-  if (initialPosition > 0) {
-    CMTime seekTime = CMTimeMake(initialPosition, 30);
-    [_player seekToTime:seekTime toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
-  }
-
   // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
   // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
   // video streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116). An
   // invisible AVPlayerLayer is used to overwrite the protection of pixel buffers in those streams
   // for issue #1, and restore the correct width and height for issue #2.
   _playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
+
+  if (initialPosition > 0) {
+    CMTime seekTime = CMTimeMake(initialPosition, 1000);
+    [_player seekToTime:seekTime toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+  }
 
   [rootViewController().view.layer addSublayer:_playerLayer];
 

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -274,17 +274,17 @@ NS_INLINE UIViewController *rootViewController(void) {
   _player = [playerFactory playerWithPlayerItem:item];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
 
+  if (initialPosition > 0) {
+    CMTime seekTime = CMTimeMake(initialPosition, 30);
+    [_player seekToTime:seekTime toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+  }
+
   // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
   // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
   // video streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116). An
   // invisible AVPlayerLayer is used to overwrite the protection of pixel buffers in those streams
   // for issue #1, and restore the correct width and height for issue #2.
   _playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
-
-  if (initialPosition > 0) {
-    CMTime seekTime = CMTimeMake(initialPosition, 1000);
-    [_player seekToTime:seekTime toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
-  }
 
   [rootViewController().view.layer addSublayer:_playerLayer];
 

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
@@ -73,12 +73,14 @@ NS_ASSUME_NONNULL_BEGIN
     uri:(nullable NSString *)uri
     packageName:(nullable NSString *)packageName
     formatHint:(nullable NSString *)formatHint
-    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders;
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+    initialPosition:(nullable NSNumber *)initialPosition;
 @property(nonatomic, copy, nullable) NSString * asset;
 @property(nonatomic, copy, nullable) NSString * uri;
 @property(nonatomic, copy, nullable) NSString * packageName;
 @property(nonatomic, copy, nullable) NSString * formatHint;
 @property(nonatomic, strong) NSDictionary<NSString *, NSString *> * httpHeaders;
+@property(nonatomic, strong, nullable) NSNumber * initialPosition;
 @end
 
 @interface FLTMixWithOthersMessage : NSObject

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
@@ -213,13 +213,15 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     uri:(nullable NSString *)uri
     packageName:(nullable NSString *)packageName
     formatHint:(nullable NSString *)formatHint
-    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders {
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+    initialPosition:(nullable NSNumber *)initialPosition {
   FLTCreateMessage* pigeonResult = [[FLTCreateMessage alloc] init];
   pigeonResult.asset = asset;
   pigeonResult.uri = uri;
   pigeonResult.packageName = packageName;
   pigeonResult.formatHint = formatHint;
   pigeonResult.httpHeaders = httpHeaders;
+  pigeonResult.initialPosition = initialPosition;
   return pigeonResult;
 }
 + (FLTCreateMessage *)fromList:(NSArray *)list {
@@ -230,6 +232,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.formatHint = GetNullableObjectAtIndex(list, 3);
   pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 4);
   NSAssert(pigeonResult.httpHeaders != nil, @"");
+  pigeonResult.initialPosition = GetNullableObjectAtIndex(list, 5);
   return pigeonResult;
 }
 + (nullable FLTCreateMessage *)nullableFromList:(NSArray *)list {
@@ -242,6 +245,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     (self.packageName ?: [NSNull null]),
     (self.formatHint ?: [NSNull null]),
     (self.httpHeaders ?: [NSNull null]),
+    (self.initialPosition ?: [NSNull null]),
   ];
 }
 @end

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -31,7 +31,10 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<int?> create(DataSource dataSource) async {
+  Future<int?> create(
+    DataSource dataSource, {
+    Duration? initialPosition,
+  }) async {
     String? asset;
     String? packageName;
     String? uri;
@@ -60,6 +63,7 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
       uri: uri,
       httpHeaders: httpHeaders,
       formatHint: formatHint,
+      initialPosition: initialPosition?.inMilliseconds,
     );
 
     final TextureMessage response = await _api.create(message);

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -143,6 +143,7 @@ class CreateMessage {
     this.packageName,
     this.formatHint,
     required this.httpHeaders,
+    this.initialPosition,
   });
 
   String? asset;
@@ -155,6 +156,8 @@ class CreateMessage {
 
   Map<String?, String?> httpHeaders;
 
+  int? initialPosition;
+
   Object encode() {
     return <Object?>[
       asset,
@@ -162,6 +165,7 @@ class CreateMessage {
       packageName,
       formatHint,
       httpHeaders,
+      initialPosition,
     ];
   }
 
@@ -172,7 +176,9 @@ class CreateMessage {
       uri: result[1] as String?,
       packageName: result[2] as String?,
       formatHint: result[3] as String?,
-      httpHeaders: (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      httpHeaders:
+          (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      initialPosition: result[5] as int?,
     );
   }
 }

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -50,6 +50,7 @@ class CreateMessage {
   String? packageName;
   String? formatHint;
   Map<String?, String?> httpHeaders;
+  int? initialPosition;
 }
 
 class MixWithOthersMessage {

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -116,7 +116,7 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
 
 class _PlaceholderImplementation extends VideoPlayerPlatform {}
 
-/// Pepresents a media track
+/// Represents a media track
 class Track {
   /// Creates a new track
   const Track(this.name, [this.selected = false]);

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -49,7 +49,7 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   }
 
   /// Creates an instance of a video player and returns its textureId.
-  Future<int?> create(DataSource dataSource) {
+  Future<int?> create(DataSource dataSource, {Duration? initialPosition}) {
     throw UnimplementedError('create() has not been implemented.');
   }
 

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -47,7 +47,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
   }
 
   @override
-  Future<int> create(DataSource dataSource) async {
+  Future<int> create(DataSource dataSource, {int? initialPosition}) async {
     final int textureId = _textureCounter++;
 
     late String uri;


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**


This PR adds an optional argument to the `initialize` method of `VideoPlayerController`, allowing buffering to start from a position other than T0.
```
_controller = VideoPlayerController.networkUrl(
  Uri.parse(
    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
  ),
);

_controller.initialize(
  initialPosition: const Duration(seconds: 10),
);
```

It will pass down the position to the `VideoPlayerPlatform.create` method, which then forwards it to the native layer through `CreateMessage`.
In the native layer, we call `seek(initialPosition)` after creating the player.
